### PR TITLE
ci: fix scorecard-action SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
Fix OpenSSF Scorecard action failing with "imposter commit" error.

## Problem
The v2.4.0 tag is an **annotated tag**, so we need the dereferenced commit SHA, not the tag object SHA.

## Fix
- `ff5dd8929f96a8a4dc67d13f32b8c75057829621` (tag object) → `62b2cac7ed8198b15735ed49ab1e5cf35480ba46` (commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)