### PR TITLE
ci: fix codeql-action SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,6 +31,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@a4fda0891d53e117609b7ddb3570638c2c6d7c89
+        uses: github/codeql-action/upload-sarif@4bdb89f48054571735e3792627da6195c57459e2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
Fix codeql-action/upload-sarif "imposter commit" error.

## Fix
v3 tag is annotated → use dereferenced commit SHA:
`4bdb89f48054571735e3792627da6195c57459e2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)