### PR TITLE
fixes för ci breakage grundat i windows-implementationen där python -m pip behövs för att undvika versionsproblem

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -31,17 +31,17 @@ runs:
         python -m pip --version || true
         if [ -n "$WHEEL" ] && [ -d "$WHEEL" ] && [ -f "$LOCK" ]; then
           # Try offline first, fall back to network (needed for macOS/Windows wheels)
-          if pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCK"; then
+          if python -m pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCK"; then
             echo "Installed from wheelhouse (offline)"
           else
             echo "Offline install failed, falling back to network install"
-            pip install --find-links "$WHEEL" --require-hashes -r "$LOCK"
+            python -m pip install --find-links "$WHEEL" --require-hashes -r "$LOCK"
           fi
         elif [ -f "$LOCK" ]; then
-          pip install --require-hashes -r "$LOCK"
+          python -m pip install --require-hashes -r "$LOCK"
         else
           if [ -f requirements.lock ]; then
-            pip install --require-hashes -r requirements.lock
+            python -m pip install --require-hashes -r requirements.lock
           else
             echo "ERROR: no lockfile found at $LOCK and no requirements.lock present" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,18 +128,18 @@ jobs:
           LOCKFILE=lockfiles/requirements.lock-3.12
           WHEEL=wheelhouse/3.12
           if [ -d "$WHEEL" ] && [ -f "$LOCKFILE" ]; then
-            pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCKFILE"
+            python -m pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCKFILE"
           elif [ -f "$LOCKFILE" ]; then
-            pip install --require-hashes -r "$LOCKFILE"
+            python -m pip install --require-hashes -r "$LOCKFILE"
           else
-            pip install --require-hashes -r requirements.lock
+            python -m pip install --require-hashes -r requirements.lock
           fi
           # Attempt offline install of SBOM tooling from the wheelhouse to avoid
           # network egress in hardened jobs. If the package is not present in
           # the wheelhouse, skip installation rather than attempting a network
           # fetch which will fail under the hardened runner.
           if [ -d "$WHEEL" ]; then
-            if pip install --no-index --find-links "$WHEEL" cyclonedx-bom; then
+            if python -m pip install --no-index --find-links "$WHEEL" cyclonedx-bom; then
               echo "Installed cyclonedx-bom from wheelhouse"
             else
               echo "WARNING: cyclonedx-bom not found in wheelhouse; skipping SBOM tooling installation to avoid network egress"
@@ -383,11 +383,11 @@ jobs:
           LOCK=lockfiles/requirements.lock-${{ matrix.python-version }}
           WHEEL=wheelhouse/${{ matrix.python-version }}
           if [ -d "$WHEEL" ] && [ -f "$LOCK" ]; then
-            pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCK"
+            python -m pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCK"
           elif [ -f "$LOCK" ]; then
-            pip install --require-hashes -r "$LOCK"
+            python -m pip install --require-hashes -r "$LOCK"
           else
-            pip install --require-hashes -r requirements.lock
+            python -m pip install --require-hashes -r requirements.lock
           fi
       - name: Quick tests (single seed, no coverage)
         # Allow Python 3.14 to fail: Ecosystem libraries not yet fully compatible
@@ -477,15 +477,15 @@ jobs:
           # platform-specific packages (e.g., aiohttp with native extensions).
           if [ -d "$WHEEL" ] && [ -f "$LOCK" ]; then
             if [ "$RUNNER_OS" = "Linux" ]; then
-              pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCK"
+              python -m pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCK"
             else
               # Non-Linux: use wheelhouse as cache but allow PyPI fallback
-              pip install --find-links "$WHEEL" --require-hashes -r "$LOCK"
+              python -m pip install --find-links "$WHEEL" --require-hashes -r "$LOCK"
             fi
           elif [ -f "$LOCK" ]; then
-            pip install --require-hashes -r "$LOCK"
+            python -m pip install --require-hashes -r "$LOCK"
           else
-            pip install --require-hashes -r requirements.lock
+            python -m pip install --require-hashes -r requirements.lock
           fi
       - name: Run tests with two random seeds
         shell: bash
@@ -563,9 +563,9 @@ jobs:
           python -m pip --version
           LOCK=lockfiles/requirements.lock-${{ matrix.python-version }}
           if [ -f "$LOCK" ]; then
-            pip install --require-hashes -r "$LOCK"
+            python -m pip install --require-hashes -r "$LOCK"
           else
-            pip install --require-hashes -r requirements.lock
+            python -m pip install --require-hashes -r requirements.lock
           fi
       - name: Run tests with two random seeds
         env:
@@ -764,7 +764,7 @@ jobs:
           # Try to install SBOM tooling from local wheelhouse to avoid network egress
           WHEEL=wheelhouse/${{ matrix.python-version }}
           if [ -d "$WHEEL" ]; then
-            if pip install --no-index --find-links "$WHEEL" cyclonedx-bom; then
+            if python -m pip install --no-index --find-links "$WHEEL" cyclonedx-bom; then
               echo "Installed cyclonedx-bom from wheelhouse"
             else
               echo "WARNING: cyclonedx-bom not found in wheelhouse; skipping SBOM generation to avoid network egress"
@@ -1292,11 +1292,11 @@ jobs:
           LOCK=lockfiles/requirements.lock-3.12
           WHEEL=wheelhouse/3.12
           if [ -d "$WHEEL" ] && [ -f "$LOCK" ]; then
-            pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCK"
+            python -m pip install --no-index --find-links "$WHEEL" --require-hashes -r "$LOCK"
           elif [ -f "$LOCK" ]; then
-            pip install --require-hashes -r "$LOCK"
+            python -m pip install --require-hashes -r "$LOCK"
           else
-            pip install --require-hashes -r requirements.lock
+            python -m pip install --require-hashes -r requirements.lock
           fi
       - name: Interrogate (docstring coverage 100%)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ sbom-*.json
 .sbomenv/
 .sbomvenv/
 cyclonedx*.json
+
+PRESENTATION.md

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Detta projekt är en datapipeline som omvandlar rå svensk skolstatistik till AI
 - [🔒 CI/CD: Extremt strikt läge](#cicd-extremt-strikt-läge)
 - [🧷 Pre-commit: lokala kvalitetsgrindar](#pre-commit-lokala-kvalitetsgrindar)
 - [🤖 Byta till en annan LLM](#byta-till-en-annan-llm)
+- [Avgränsningar för LLM-utvärdering](#avgränsningar-för-llm-utvärdering)
 - [🪪 Licens](#licens)
 
 ## 🔍 Översikt
@@ -425,6 +426,10 @@ pre-commit run --all-files
 # eller endast licenskollen
 python tools/policy/check_licenses.py
 ```
+
+## Avgränsningar för LLM-utvärdering
+
+Vi testar medvetet inte LLM‑utdata utifrån kvalitet, konsistens eller liknande bedömningskriterier. Den typen av utvärdering ligger utanför projektets relevanta scope i detta repo. Exemplet här är avsett som en teknisk demonstration, och vi publicerar inte en mer verksamhetsnära implementation än den som visas.
 
 ## 🪪 Licens
 

--- a/README_en_US.md
+++ b/README_en_US.md
@@ -43,6 +43,7 @@ This project is a data processing pipeline that transforms raw Swedish school st
 - [🔒 CI/CD: Extreme Strict Mode](#cicd-extreme-strict-mode)
 - [🧷 Pre-commit: Local Quality Gates](#pre-commit-local-quality-gates)
 - [🤖 Switching to a different LLM](#switching-to-a-different-llm)
+- [Scope Limitations for LLM Evaluation](#scope-limitations-for-llm-evaluation)
 - [🪪 License](#license)
 
 ## 🔍 Overview
@@ -424,3 +425,7 @@ pre-commit run --all-files
 # or just the license check
 python tools/policy/check_licenses.py
 ```
+
+## Scope Limitations for LLM Evaluation
+
+We intentionally do not test LLM outputs for quality, consistency, or similar subjective criteria. That evaluation is out of scope for this repository. The implementation shown here is a technical demonstration, and we do not publish a more business-specific implementation beyond what is presented.


### PR DESCRIPTION
ci: use python -m pip for package installations in workflows
docs: update README files with scope limitations for LLM evaluation
gitignore: add PRESENTATION.md to ignore list